### PR TITLE
EditHandle: Add ResizedWidth and ResizedHeight

### DIFF
--- a/src/AupDotNet/EditHandle.cs
+++ b/src/AupDotNet/EditHandle.cs
@@ -108,13 +108,19 @@ namespace Karoterra.AupDotNet
         }
 
         /// <summary>
-        /// フレームの横幅。
+        /// フレームのサイズ変更前の横幅。
         /// </summary>
+        /// <remarks>
+        /// プロジェクト作成時の横幅。
+        /// </remarks>
         public int Width { get; set; }
 
         /// <summary>
-        /// フレームの高さ。
+        /// フレームのサイズ変更前の高さ。
         /// </summary>
+        /// <remarks>
+        /// プロジェクト作成時の高さ。
+        /// </remarks>
         public int Height { get; set; }
 
         /// <summary>
@@ -126,6 +132,24 @@ namespace Karoterra.AupDotNet
         /// 選択中フレームの終了フレーム。
         /// </summary>
         public int SelectedFrameEnd { get; set; }
+
+        /// <summary>
+        /// フレームのサイズ変更後の横幅。
+        /// </summary>
+        /// <remarks>
+        /// AviUtlの「サイズの変更」やサイズ変更系のフィルタープラグインを使用してサイズを変更した場合の横幅。
+        /// 使用していない(変更していない)場合プロジェクト作成時の横幅と同じになる。
+        /// </remarks>
+        public int ResizedWidth { get; set; }
+
+        /// <summary>
+        /// フレームのサイズ変更後の高さ。
+        /// </summary>
+        /// <remarks>
+        /// AviUtlの「サイズの変更」やサイズ変更系のフィルタープラグインを使用してサイズを変更した場合の高さ。
+        /// 使用していない(変更していない)場合プロジェクト作成時の高さと同じになる。
+        /// </remarks>
+        public int ResizedHeight { get; set; }
 
         /// <summary>
         /// 現在表示中のフレーム。
@@ -218,6 +242,8 @@ namespace Karoterra.AupDotNet
             Height = span.Slice(0x314 - UncompressedSize, 4).ToInt32();
             SelectedFrameStart = span.Slice(0x31c - UncompressedSize, 4).ToInt32();
             SelectedFrameEnd = span.Slice(0x320 - UncompressedSize, 4).ToInt32();
+            ResizedWidth = span.Slice(0x328 - UncompressedSize, 4).ToInt32();
+            ResizedHeight = span.Slice(0x32c - UncompressedSize, 4).ToInt32();
             CurrentFrame = span.Slice(0x330 - UncompressedSize, 4).ToInt32();
             VideoDecodeBit = span.Slice(0x3de - UncompressedSize, 2).ToInt16();
             VideoDecodeFormat = span.Slice(0x3e0 - UncompressedSize, 4).ToUInt32();
@@ -298,6 +324,8 @@ namespace Karoterra.AupDotNet
             Frames.Count.ToBytes().CopyTo(span.Slice(0x318 - UncompressedSize, 4));
             SelectedFrameStart.ToBytes().CopyTo(span.Slice(0x31c - UncompressedSize, 4));
             SelectedFrameEnd.ToBytes().CopyTo(span.Slice(0x320 - UncompressedSize, 4));
+            ResizedWidth.ToBytes().CopyTo(span.Slice(0x328 - UncompressedSize, 4));
+            ResizedHeight.ToBytes().CopyTo(span.Slice(0x32c - UncompressedSize, 4));
             CurrentFrame.ToBytes().CopyTo(span.Slice(0x330 - UncompressedSize, 4));
             VideoDecodeBit.ToBytes().CopyTo(span.Slice(0x3de - UncompressedSize, 2));
             VideoDecodeFormat.ToBytes().CopyTo(span.Slice(0x3e0 - UncompressedSize, 4));

--- a/testdata/EditHandle/640x480_2997-100fps_44100Hz_edithandle.json
+++ b/testdata/EditHandle/640x480_2997-100fps_44100Hz_edithandle.json
@@ -7,6 +7,8 @@
   "FrameNum": 6,
   "SelectedFrameStart": 0,
   "SelectedFrameEnd": 5,
+  "ResizedWidth": 640,
+  "ResizedHeight": 480,
   "CurrentFrame": 3,
   "AudioCh": 2,
   "AudioRate": 44100,

--- a/tests/AupDotNetTests/EditHandleTest.cs
+++ b/tests/AupDotNetTests/EditHandleTest.cs
@@ -18,6 +18,8 @@ namespace AupDotNetTests
         public int FrameNum { get; set; }
         public int SelectedFrameStart { get; set; }
         public int SelectedFrameEnd { get; set; }
+        public int ResizedWidth { get; set; }
+        public int ResizedHeight { get; set; }
         public int CurrentFrame { get; set; }
         public short AudioCh { get; set; }
         public int AudioRate { get; set; }
@@ -47,6 +49,8 @@ namespace AupDotNetTests
             Assert.AreEqual(expected.FrameNum, aup.EditHandle.Frames.Count, "FrameNum");
             Assert.AreEqual(expected.SelectedFrameStart, aup.EditHandle.SelectedFrameStart, "SelectedFrameStart");
             Assert.AreEqual(expected.SelectedFrameEnd, aup.EditHandle.SelectedFrameEnd, "SelectedFrameEnd");
+            Assert.AreEqual(expected.ResizedWidth, aup.EditHandle.ResizedWidth, "ResizedWidth");
+            Assert.AreEqual(expected.ResizedHeight, aup.EditHandle.ResizedHeight, "ResizedHeight");
             Assert.AreEqual(expected.CurrentFrame, aup.EditHandle.CurrentFrame, "CurrentFrame");
             Assert.AreEqual(expected.AudioCh, aup.EditHandle.AudioCh, "AudioCh");
             Assert.AreEqual(expected.AudioRate, aup.EditHandle.AudioRate, "AudioRate");
@@ -81,6 +85,8 @@ namespace AupDotNetTests
             Assert.AreEqual(src.Frames.Count, dst.Frames.Count, "FrameNum");
             Assert.AreEqual(src.SelectedFrameStart, dst.SelectedFrameStart, "SelectedFrameStart");
             Assert.AreEqual(src.SelectedFrameEnd, dst.SelectedFrameEnd, "SelectedFrameEnd");
+            Assert.AreEqual(src.ResizedWidth, dst.ResizedWidth, "ResizedWidth");
+            Assert.AreEqual(src.ResizedHeight, dst.ResizedHeight, "ResizedHeight");
             Assert.AreEqual(src.CurrentFrame, dst.CurrentFrame, "CurrentFrame");
             Assert.AreEqual(src.VideoDecodeBit, dst.VideoDecodeBit, "VideoDecodeBit");
             Assert.AreEqual(src.VideoDecodeFormat, dst.VideoDecodeFormat, "VideoDecodeFormat");


### PR DESCRIPTION
エディットハンドルのオフセット0x328, 0x32c(どちらも4bytes)には
AviUtlで「設定」→「サイズの変更」をしたり、サイズを変更する系のフィルタープラグインでサイズを変更した後の幅と高さが格納されるみたいです
なのでそれらを追加してみました
