### PR TITLE
Update dependencies to address security advisory

### DIFF
--- a/src/AupDotNet/AupDotNet.csproj
+++ b/src/AupDotNet/AupDotNet.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/tests/AupDotNetTests/AupDotNetTests.csproj
+++ b/tests/AupDotNetTests/AupDotNetTests.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.IO.Compression" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">


### PR DESCRIPTION
セキュリティアドバイザリーのあった以下のパッケージを更新

- System.IO.Packaging 6.0.0 ➡️ 6.0.2
  - [Microsoft Security Advisory CVE-2024-43483 | .NET Denial of Service Vulnerability · CVE-2024-43483 · GitHub Advisory Database](https://github.com/advisories/GHSA-qj66-m88j-hmgj)
  - [Microsoft Security Advisory CVE-2024-43484 | .NET Denial of Service Vulnerability · CVE-2024-43484 · GitHub Advisory Database](https://github.com/advisories/GHSA-f32c-w444-8ppv)
- System.Text.Json 6.0.1 ➡️ 6.0.11
  - [Microsoft Security Advisory CVE-2024-43485 | .NET Denial of Service Vulnerability · CVE-2024-43485 · GitHub Advisory Database](https://github.com/advisories/GHSA-8g4q-xg66-9fp4)