### PR TITLE
Fix EffectType detection in EffectFactory for patch.aul (#3)

### DIFF
--- a/src/AupDotNet/ExEdit/EffectFactory.cs
+++ b/src/AupDotNet/ExEdit/EffectFactory.cs
@@ -16,10 +16,6 @@ namespace Karoterra.AupDotNet.ExEdit
             {
                 return new CustomEffect(type, trackbars, checkboxes, data);
             }
-            if (!type.Equals(EffectType.Defaults[type.Id]))
-            {
-                return new CustomEffect(type, trackbars, checkboxes, data);
-            }
 
             return (EffectTypeId)type.Id switch
             {


### PR DESCRIPTION
#3 への対応
patch.aul導入環境で作成したaupファイルではバニラ環境のものと比べて `EffectType.Flag` が変化する。
`Flag` が変わっても `Effect` のパラメータには影響がないだろうということで、 `EffectType.Id` だけで判定するように変更。