### PR TITLE
Update framework to net8

### DIFF
--- a/src/AupDotNet/AupDotNet.csproj
+++ b/src/AupDotNet/AupDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>Karoterra.AupDotNet</RootNamespace>
     <AssemblyName>Karoterra.AupDotNet</AssemblyName>
     <PackageId>Karoterra.AupDotNet</PackageId>

--- a/src/AupDotNet/MaxByteCountOfStringException.cs
+++ b/src/AupDotNet/MaxByteCountOfStringException.cs
@@ -45,15 +45,5 @@ namespace Karoterra.AupDotNet
             : base($"Byte count of {name} must be less than {maxSize}.")
         {
         }
-
-        /// <summary>
-        /// シリアル化したデータを使用して、<see cref="MaxByteCountOfStringException"/> のインスタンスを初期化します。
-        /// </summary>
-        /// <param name="info">シリアル化されたオブジェクトデータを保持するオブジェクト。</param>
-        /// <param name="context">転送元または転送先に関するコンテキスト情報。</param>
-        protected MaxByteCountOfStringException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
     }
 }

--- a/tests/AupDotNetTests/AupDotNetTests.csproj
+++ b/tests/AupDotNetTests/AupDotNetTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
.NET 6 は Microsoft 公式のサポート期間が終了したため、対応フレームワークから外した。
代わりに LTS の .NET 8 を対応フレームワークにした。