### PR TITLE
Upgrade dependencies

### DIFF
--- a/src/AupDotNet/AupDotNet.csproj
+++ b/src/AupDotNet/AupDotNet.csproj
@@ -28,11 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="6.0.2" />
+    <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AupDotNetTests/AupDotNetTests.csproj
+++ b/tests/AupDotNetTests/AupDotNetTests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -22,7 +22,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.IO.Compression" />
-    <PackageReference Include="System.Text.Json" Version="6.0.11" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/tests/AupDotNetTests/ExEdit/TrackbarTest.cs
+++ b/tests/AupDotNetTests/ExEdit/TrackbarTest.cs
@@ -16,7 +16,7 @@ namespace AupDotNetTests.ExEdit
         [DataRow(0x1234006FU, TrackbarType.Script, TrackbarFlag.Acceleration | TrackbarFlag.Deceleration, 0x1234)]
         [DataRow(0x00010040U, TrackbarType.Stop, TrackbarFlag.Acceleration, 1)]
         [DataRow(0x00000021U, TrackbarType.Liner, TrackbarFlag.Deceleration, 0)]
-        [DataRow(0x00100002U, TrackbarType.Curve, 0, 0x10)]
+        [DataRow(0x00100002U, TrackbarType.Curve, (TrackbarFlag)0, 0x10)]
         public void Test_Transition(uint transition, TrackbarType type, TrackbarFlag flag, int script)
         {
             Trackbar trackbar = new Trackbar(0, 0, transition, 0);


### PR DESCRIPTION
AupDotNetの依存パッケージと、テスト用のパッケージを更新した。
テストのターゲットフレームワークから netcoreapp3.1 を外した。